### PR TITLE
Support code text `〜`

### DIFF
--- a/src/font-config.satyh
+++ b/src/font-config.satyh
@@ -1,4 +1,5 @@
 @require: math
+@require: code
 
 @import: document-config
 
@@ -205,6 +206,7 @@ end = struct
   %% standard-context
   let get-standard-context wid =
     get-initial-context wid (command \math)
+    |> set-code-text-command (command \code)
     |> set-dominant-wide-script Kana
     |> set-language Kana Japanese
     |> set-language HanIdeographic Japanese


### PR DESCRIPTION
This PR attempts to make the class file support code text syntax ``{… `foo` …}`` as an abbreviation for ``{… \code(`foo`); …}``.